### PR TITLE
fix  bug : construct method will throw cannot create destination exception if the destination dir already exists

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -541,7 +541,7 @@ class Upload {
 
 		$this->destination = $destination . DIRECTORY_SEPARATOR;
 
-		return $this->destination_exist() ?: $this->create_destination();
+		return $this->destination_exist() ? TRUE : $this->create_destination();
 
 	}
 


### PR DESCRIPTION
The set_destination mthod will always return '' if the destination dir
exists, then the construct mehtod will throw cannot create destination
exception