### PR TITLE
fix permission

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -12,7 +12,7 @@ class Upload {
 	/**
 	 * Default directory persmissions (destination dir)
 	 */
-	protected $default_permissions = 750;
+	protected $default_permissions = 0750;
 
 
 	/**


### PR DESCRIPTION
mkdir needs octal value. Your default will cause a real CHMOD of 354 (-wxr-xr-T) which is fatal, as it can't be removed through FTP-User :)