### PR TITLE
Fixed typo in property name

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -20,7 +20,7 @@ class Upload {
 	 *
 	 * @var array
 	 */
-	protected $files_post = array();
+	protected $file_post = array();
 
 
 	/**
@@ -66,7 +66,7 @@ class Upload {
 	/**
 	 * External callback object
 	 *
-	 * @var obejct
+	 * @var object
 	 */
 	protected $external_callback_object;
 
@@ -394,7 +394,7 @@ class Upload {
 	/**
 	 * File mime type validation callback
 	 *
-	 * @param obejct $object
+	 * @param object $object
 	 */
 	protected function check_mime_type($object) {
 


### PR DESCRIPTION
- The code uses `$file_post` instead of `$files_post`, so `$file_post` is a public variable that allows you to modify it from the outside.
- Fixed other typo